### PR TITLE
Fix `TypeError: Cannot read property 'members' of undefined` error

### DIFF
--- a/src/rules/reactPureComponentsHaveSimpleAttributesRule.ts
+++ b/src/rules/reactPureComponentsHaveSimpleAttributesRule.ts
@@ -150,7 +150,7 @@ function inspectComponentPropsTypeReference(
 	if (type) {
 		// Unpack symbolic data
 		const typeSymbol = type.getSymbol() as ts.Symbol
-		const typeSymbolMembers = typeSymbol.members
+		const typeSymbolMembers = typeSymbol!.members
 		if (typeSymbolMembers) {
 			// Inspect target type members
 			typeSymbolMembers.forEach((member: ts.Symbol, key: ts.__String) => {


### PR DESCRIPTION
Getting a lot of `TypeError: Cannot read property 'members' of undefined` error running the tslint perf. Did not dig too much but the `getSymbol` type in typescript defintiion is 
``` 
interface Type {
        getFlags(): TypeFlags;
        getSymbol(): Symbol | undefined;   <-----
```
So `const typeSymbol = type.getSymbol() as ts.Symbol` seems to return undefined for symbol sometimes. It needs to make additional undefined check before accessing members property.